### PR TITLE
Support bson.Symbol for report

### DIFF
--- a/mongoreplay/util.go
+++ b/mongoreplay/util.go
@@ -401,6 +401,9 @@ func ConvertBSONValueToJSON(x interface{}) (interface{}, error) {
 	case string:
 		return v, nil // require no conversion
 
+	case bson.Symbol:
+		return v, nil // require no conversion
+
 	case int:
 		return json.NumberInt(v), nil
 


### PR DESCRIPTION
This PR fixes `error recording stat: conversion of BSON type 'bson.Symbol' not supported a10`

[test.playback.gz](https://github.com/mongodb-labs/mongoreplay/files/4677370/test.playback.gz)

## Before

```
$ bin/mongoreplay play -p test.playback.gz --host mongo --speed 100 --collect=json --gzip
2020/05/25 13:30:28 Doing playback at 100.00x speed
2020/05/25 13:30:28 Preprocessing file
2020/05/25 13:30:28 Preprocess complete
2020/05/25 13:30:28 error recording stat: conversion of BSON type 'bson.Symbol' not supported a10
{"order":0,"op":"op_msg","command":"update","ns":"testing","request_data":null,"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:30:28.860204Z","play_at":"2020-05-25T13:30:28.8595137Z","playbacklag_us":677,"connection_num":1,"latency_us":2223,"seen":"2020-05-25T11:54:35.5192883Z","request_id":20}
2020/05/25 13:30:28 error recording stat: conversion of BSON type 'bson.Symbol' not supported a11
{"order":2,"op":"op_msg","command":"update","ns":"testing","request_data":null,"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:30:28.8786606Z","play_at":"2020-05-25T13:30:28.864555241Z","playbacklag_us":14086,"connection_num":1,"latency_us":106373,"seen":"2020-05-25T11:54:36.0234424Z","request_id":21}
2020/05/25 13:30:28 error recording stat: conversion of BSON type 'bson.Symbol' not supported a12
{"order":4,"op":"op_msg","command":"update","ns":"testing","request_data":null,"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:30:28.9854377Z","play_at":"2020-05-25T13:30:28.869623947Z","playbacklag_us":115810,"connection_num":1,"latency_us":1874,"seen":"2020-05-25T11:54:36.530313Z","request_id":22}
2020/05/25 13:30:29 error recording stat: conversion of BSON type 'bson.Symbol' not supported a13
{"order":6,"op":"op_msg","command":"update","ns":"testing","request_data":null,"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:30:28.9898829Z","play_at":"2020-05-25T13:30:28.874671016Z","playbacklag_us":115316,"connection_num":1,"latency_us":33578,"seen":"2020-05-25T11:54:37.0350199Z","request_id":23}
2020/05/25 13:30:29 error recording stat: conversion of BSON type 'bson.Symbol' not supported a14
{"order":8,"op":"op_msg","command":"update","ns":"testing","request_data":null,"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:30:29.0243637Z","play_at":"2020-05-25T13:30:28.879718376Z","playbacklag_us":144624,"connection_num":1,"latency_us":34359,"seen":"2020-05-25T11:54:37.5397559Z","request_id":24}
2020/05/25 13:30:29 error recording stat: conversion of BSON type 'bson.Symbol' not supported a15
{"order":10,"op":"op_msg","command":"update","ns":"testing","request_data":null,"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:30:29.0590586Z","play_at":"2020-05-25T13:30:28.884781423Z","playbacklag_us":174258,"connection_num":1,"latency_us":2161,"seen":"2020-05-25T11:54:38.0460606Z","request_id":25}
2020/05/25 13:30:29 error recording stat: conversion of BSON type 'bson.Symbol' not supported a24
{"order":12,"op":"op_msg","command":"update","ns":"testing","request_data":null,"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:30:29.0630945Z","play_at":"2020-05-25T13:30:28.930368739Z","playbacklag_us":132702,"connection_num":1,"latency_us":91314,"seen":"2020-05-25T11:54:42.6047922Z","request_id":34}
2020/05/25 13:30:29 error recording stat: conversion of BSON type 'bson.Symbol' not supported a25
{"order":14,"op":"op_msg","command":"update","ns":"testing","request_data":null,"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:30:29.1579981Z","play_at":"2020-05-25T13:30:28.935411848Z","playbacklag_us":230922,"connection_num":1,"latency_us":3811,"seen":"2020-05-25T11:54:43.1091031Z","request_id":35}
2020/05/25 13:30:29 error recording stat: conversion of BSON type 'bson.Symbol' not supported a26
{"order":16,"op":"op_msg","command":"update","ns":"testing","request_data":null,"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:30:29.1704704Z","play_at":"2020-05-25T13:30:28.940446771Z","playbacklag_us":230008,"connection_num":1,"latency_us":8886,"seen":"2020-05-25T11:54:43.6125954Z","request_id":36}
2020/05/25 13:30:29 error recording stat: conversion of BSON type 'bson.Symbol' not supported a27
{"order":18,"op":"op_msg","command":"update","ns":"testing","request_data":null,"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:30:29.1796701Z","play_at":"2020-05-25T13:30:28.945489225Z","playbacklag_us":234161,"connection_num":1,"latency_us":1093,"seen":"2020-05-25T11:54:44.1168408Z","request_id":37}
2020/05/25 13:30:29 21 ops played back in 358.1351ms seconds over 1 connections
```

## After

```
$ bin/mongoreplay play -p test.playback.gz --host mongo --speed 100 --collect=json --gzip
2020/05/25 13:31:59 Doing playback at 100.00x speed
2020/05/25 13:31:59 Preprocessing file
2020/05/25 13:31:59 Preprocess complete
{"order":0,"op":"op_msg","command":"update","ns":"testing","request_data":{"sections":[{"payload":{"$db":"testing","lsid":{"id":{"$binary":"zdld4vEvRueMeRQwdQ97gw==","$type":"04"}},"ordered":true,"update":"numbers"},"payloadType":0},{"payload":{"documents":[{"q":{"_id":{"$oid":"5ecbb1f6473a47dea332964d"}},"u":{"value":"a10"}}],"identifier":"updates","size":65},"payloadType":1}]},"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:31:59.2852798Z","play_at":"2020-05-25T13:31:59.2849907Z","playbacklag_us":288,"connection_num":1,"latency_us":13644,"seen":"2020-05-25T11:54:35.5192883Z","request_id":20}
{"order":2,"op":"op_msg","command":"update","ns":"testing","request_data":{"sections":[{"payload":{"$db":"testing","lsid":{"id":{"$binary":"zdld4vEvRueMeRQwdQ97gw==","$type":"04"}},"ordered":true,"update":"numbers"},"payloadType":0},{"payload":{"documents":[{"q":{"_id":{"$oid":"5ecbb1f6473a47dea332964d"}},"u":{"value":"a11"}}],"identifier":"updates","size":65},"payloadType":1}]},"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:31:59.3011754Z","play_at":"2020-05-25T13:31:59.290032241Z","playbacklag_us":11151,"connection_num":1,"latency_us":34159,"seen":"2020-05-25T11:54:36.0234424Z","request_id":21}
{"order":4,"op":"op_msg","command":"update","ns":"testing","request_data":{"sections":[{"payload":{"$db":"testing","lsid":{"id":{"$binary":"zdld4vEvRueMeRQwdQ97gw==","$type":"04"}},"ordered":true,"update":"numbers"},"payloadType":0},{"payload":{"documents":[{"q":{"_id":{"$oid":"5ecbb1f6473a47dea332964d"}},"u":{"value":"a12"}}],"identifier":"updates","size":65},"payloadType":1}]},"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:31:59.3362283Z","play_at":"2020-05-25T13:31:59.295100947Z","playbacklag_us":41125,"connection_num":1,"latency_us":769,"seen":"2020-05-25T11:54:36.530313Z","request_id":22}
{"order":6,"op":"op_msg","command":"update","ns":"testing","request_data":{"sections":[{"payload":{"$db":"testing","lsid":{"id":{"$binary":"zdld4vEvRueMeRQwdQ97gw==","$type":"04"}},"ordered":true,"update":"numbers"},"payloadType":0},{"payload":{"documents":[{"q":{"_id":{"$oid":"5ecbb1f6473a47dea332964d"}},"u":{"value":"a13"}}],"identifier":"updates","size":65},"payloadType":1}]},"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:31:59.337152Z","play_at":"2020-05-25T13:31:59.300148016Z","playbacklag_us":37002,"connection_num":1,"latency_us":20109,"seen":"2020-05-25T11:54:37.0350199Z","request_id":23}
{"order":8,"op":"op_msg","command":"update","ns":"testing","request_data":{"sections":[{"payload":{"$db":"testing","lsid":{"id":{"$binary":"zdld4vEvRueMeRQwdQ97gw==","$type":"04"}},"ordered":true,"update":"numbers"},"payloadType":0},{"payload":{"documents":[{"q":{"_id":{"$oid":"5ecbb1f6473a47dea332964d"}},"u":{"value":"a14"}}],"identifier":"updates","size":65},"payloadType":1}]},"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:31:59.3578731Z","play_at":"2020-05-25T13:31:59.305195376Z","playbacklag_us":52676,"connection_num":1,"latency_us":16508,"seen":"2020-05-25T11:54:37.5397559Z","request_id":24}
{"order":10,"op":"op_msg","command":"update","ns":"testing","request_data":{"sections":[{"payload":{"$db":"testing","lsid":{"id":{"$binary":"zdld4vEvRueMeRQwdQ97gw==","$type":"04"}},"ordered":true,"update":"numbers"},"payloadType":0},{"payload":{"documents":[{"q":{"_id":{"$oid":"5ecbb1f6473a47dea332964d"}},"u":{"value":"a15"}}],"identifier":"updates","size":65},"payloadType":1}]},"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:31:59.3746992Z","play_at":"2020-05-25T13:31:59.310258423Z","playbacklag_us":64439,"connection_num":1,"latency_us":1850,"seen":"2020-05-25T11:54:38.0460606Z","request_id":25}
{"order":12,"op":"op_msg","command":"update","ns":"testing","request_data":{"sections":[{"payload":{"$db":"testing","lsid":{"id":{"$binary":"zdld4vEvRueMeRQwdQ97gw==","$type":"04"}},"ordered":true,"update":"numbers"},"payloadType":0},{"payload":{"documents":[{"q":{"_id":{"$oid":"5ecbb1f6473a47dea332964d"}},"u":{"value":"a24"}}],"identifier":"updates","size":65},"payloadType":1}]},"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:31:59.3768839Z","play_at":"2020-05-25T13:31:59.355845739Z","playbacklag_us":21036,"connection_num":1,"latency_us":1900,"seen":"2020-05-25T11:54:42.6047922Z","request_id":34}
{"order":14,"op":"op_msg","command":"update","ns":"testing","request_data":{"sections":[{"payload":{"$db":"testing","lsid":{"id":{"$binary":"zdld4vEvRueMeRQwdQ97gw==","$type":"04"}},"ordered":true,"update":"numbers"},"payloadType":0},{"payload":{"documents":[{"q":{"_id":{"$oid":"5ecbb1f6473a47dea332964d"}},"u":{"value":"a25"}}],"identifier":"updates","size":65},"payloadType":1}]},"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:31:59.3790107Z","play_at":"2020-05-25T13:31:59.360888848Z","playbacklag_us":18121,"connection_num":1,"latency_us":6314,"seen":"2020-05-25T11:54:43.1091031Z","request_id":35}
{"order":16,"op":"op_msg","command":"update","ns":"testing","request_data":{"sections":[{"payload":{"$db":"testing","lsid":{"id":{"$binary":"zdld4vEvRueMeRQwdQ97gw==","$type":"04"}},"ordered":true,"update":"numbers"},"payloadType":0},{"payload":{"documents":[{"q":{"_id":{"$oid":"5ecbb1f6473a47dea332964d"}},"u":{"value":"a26"}}],"identifier":"updates","size":65},"payloadType":1}]},"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:31:59.3866754Z","play_at":"2020-05-25T13:31:59.365923771Z","playbacklag_us":21251,"connection_num":1,"latency_us":16461,"seen":"2020-05-25T11:54:43.6125954Z","request_id":36}
{"order":18,"op":"op_msg","command":"update","ns":"testing","request_data":{"sections":[{"payload":{"$db":"testing","lsid":{"id":{"$binary":"zdld4vEvRueMeRQwdQ97gw==","$type":"04"}},"ordered":true,"update":"numbers"},"payloadType":0},{"payload":{"documents":[{"q":{"_id":{"$oid":"5ecbb1f6473a47dea332964d"}},"u":{"value":"a27"}}],"identifier":"updates","size":65},"payloadType":1}]},"reply_data":{"sections":[{"payload":{"n":1,"nModified":1,"ok":1.0},"payloadType":0}]},"played_at":"2020-05-25T13:31:59.4042014Z","play_at":"2020-05-25T13:31:59.370966225Z","playbacklag_us":33234,"connection_num":1,"latency_us":29489,"seen":"2020-05-25T11:54:44.1168408Z","request_id":37}
2020/05/25 13:31:59 21 ops played back in 151.3626ms seconds over 1 connections
```